### PR TITLE
Fixed bug where themer fails on large images

### DIFF
--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -4,6 +4,7 @@ import re
 import math
 import yaml
 import urllib.request
+import random
 
 class CachedColorParser(ColorParser):
     check = check_file_regex('^colors\.yaml$')
@@ -99,7 +100,7 @@ except ImportError:
                     new = (plists[i], center)
                     clusters[i] = new
                     diff = max(diff, self.ec_dist(old[1], new[1]))
-                logger.debug('Diff: {}'.format(diff))
+                # logger.debug('Diff: {}'.format(diff)) FIXME: requires import of debug package
                 if diff <= min_diff:
                     break
             return [map(int, c[1][0]) for c in clusters]
@@ -175,5 +176,5 @@ class KmeansColorParser(ColorParser):
         translated = {}
         for k, v in color_dict.items():
             translated[mapping[k]] = v
-        self.logger.debug(translated)
+        #self.logger.debug(translated) FIXME: requires import of debug package
         return translated


### PR DESCRIPTION
I only commented out the calls to logger.debug() because when I installed debug, it was using a deprecated call to **builtin**
