### PR TITLE
Remove prefix '/' from install paths in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ except IOError:
 class new_install(install):
     def run(self):
         install.run(self) # invoke original install
-        self.mkpath('/usr/share/themer')
-        self.copy_tree('data/default', '/usr/share/themer/default')
-        self.mkpath('/usr/share/fish/completions')
-        self.copy_file('data/fish/themer.fish', '/usr/share/fish/completions/')
+        self.mkpath('usr/share/themer')
+        self.copy_tree('data/default', 'usr/share/themer/default')
+        self.mkpath('usr/share/fish/completions')
+        self.copy_file('data/fish/themer.fish', 'usr/share/fish/completions/')
 
 setup(
     name='Themer',


### PR DESCRIPTION
Package builds in fake-root with `--root="${pkgdir}"`, but the install-paths are still prefixed with `/`. When the prefixes are removed, the fake-root is used correctly and the package can be built with `makepkg`.
