### PR TITLE
Always convert rgb values to int before formatting

### DIFF
--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -127,7 +127,7 @@ class KmeansColorParser(ColorParser):
         return points
 
     def rgb_to_hex(self, rgb):
-        return '#{}'.format(''.join(('%02x' % p for p in rgb)))
+        return '#{}'.format(''.join(('%02x' % int(p) for p in rgb)))
 
     def hex_to_rgb(self, h):
         h = h.lstrip('#')


### PR DESCRIPTION
Consistently getting

```
File "/usr/lib/python3.5/site-packages/themer/parsers/__init__.py", line 128, in <genexpr>
    return '#{}'.format(''.join(('%02x' % p for p in rgb)))
TypeError: %x format: an integer is required, not float
```

Updated `rgb_to_hex` to always coerce the primary color to an int.
