### PR TITLE
add `bright` switcher to generate bright color theme

### DIFF
--- a/scripts/themer
+++ b/scripts/themer
@@ -156,7 +156,7 @@ def activate(theme_name):
         act = activator(theme_name, theme_dir, logger)
         act.activate()
 
-def generate(color_source, config, template_dir, theme_name):
+def generate(color_source, config, template_dir, theme_name, bright):
     """Generate a new theme."""
     destination = os.path.join(THEMER_ROOT, theme_name)
     wallpaper = None
@@ -166,7 +166,7 @@ def generate(color_source, config, template_dir, theme_name):
             continue
         if (isinstance(parser.check, str) or isinstance(parser.check, re._pattern_type)) and not re.search(parser.check, color_source, re.IGNORECASE):
             continue
-        parse = parser(color_source, config, logger)
+        parse = parser(color_source, config, logger, make_bright=bright)
         colors = parse.read()
         wallpaper = parse.wallpaper
         if not wallpaper:
@@ -225,6 +225,7 @@ def get_parser():
     parser.add_option('-a', '--activate', dest='activate', action='store_true')
     parser.add_option('-v', '--verbose', dest='verbose', action='store_true')
     parser.add_option('-d', '--debug', dest='debug', action='store_true')
+    parser.add_option('-b', '--bright', dest='bright', action='store_true')
     return parser
 
 def panic(msg):
@@ -318,7 +319,7 @@ if __name__ == '__main__':
                 panic('Missing required color source')
             else:
                 color_file = args[2]
-            generate(color_file, config, template_dir, theme_name)
+            generate(color_file, config, template_dir, theme_name, options.bright)
         elif action == 'render':
             if not len(args) == 2:
                 panic('Missing required argument "theme_name"')

--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -188,14 +188,14 @@ class KmeansColorParser(ColorParser):
             'background': self.fg,
             'foreground': self.bg}
         for i, color in enumerate(itertools.cycle(colors)):
-            if i == 15:
-                color = self.normalize(color, minv=0, maxv=32)
-            elif i == 7:
-                color = self.normalize(color, minv=128, maxv=192)
-            elif i > 8:
+            if i == 0:
+                color = self.normalize(color, minv=224, maxv=256)
+            elif i == 8:
                 color = self.normalize(color, minv=160, maxv=224)
+            elif i > 8:
+                color = self.normalize(color, minv=128, maxv=192)
             else:
-                color = self.normalize(color, minv=200, maxv=256)
+                color = self.normalize(color, minv=0, maxv=56)
             color_dict['color%d' % i] = color
             if i == 15:
                 break

--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -111,13 +111,14 @@ except ImportError:
 class KmeansColorParser(ColorParser):
     check = check_file_regex('\.(jpg|png|jpeg)$')
 
-    def __init__(self, wallpaper, config, logger, k=16, bg='#0e0e0e', fg='#ffffff'):
+    def __init__(self, wallpaper, config, logger, k=16, bg='#0e0e0e', fg='#ffffff', make_bright=False):
         self.wallpaper = wallpaper
         self.config = config
         self.logger = logger
         self.bg = bg
         self.fg = fg
         self.k = k
+        self.make_bright = make_bright
 
     def _get_points_from_image(self, img):
         points = []
@@ -156,6 +157,14 @@ class KmeansColorParser(ColorParser):
 
     def read(self):
         colors = self.get_dominant_colors()
+        color_dict = self.bright(colors) if self.make_bright else self.dark(colors)
+        mapping = self.mapping()
+        translated = {}
+        for k, v in color_dict.items():
+            translated[mapping[k]] = v
+        return translated
+
+    def dark(self, colors):
         color_dict = {
             'background': self.bg,
             'foreground': self.fg}
@@ -171,16 +180,31 @@ class KmeansColorParser(ColorParser):
             color_dict['color%d' % i] = color
             if i == 15:
                 break
-        mapping = self.mapping()
-        translated = {}
-        for k, v in color_dict.items():
-            translated[mapping[k]] = v
-        return translated
+        return color_dict
+
+    def bright(self, colors):
+        colors = colors[::-1]
+        color_dict = {
+            'background': self.fg,
+            'foreground': self.bg}
+        for i, color in enumerate(itertools.cycle(colors)):
+            if i == 0:
+                color = self.normalize(color, minv=0, maxv=32)
+            elif i == 8:
+                color = self.normalize(color, minv=128, maxv=192)
+            elif i > 8:
+                color = self.normalize(color, minv=160, maxv=224)
+            else:
+                color = self.normalize(color, minv=200, maxv=256)
+            color_dict['color%d' % i] = color
+            if i == 15:
+                break
+        return color_dict
 
 class WallhavenColorParser(KmeansColorParser):
     check = 'wallhaven.cc/wallpaper/[0-9]+$'
 
-    def __init__(self, wallpaper, config, logger, k=16, bg='#0e0e0e', fg='#ffffff'):
+    def __init__(self, wallpaper, config, logger, k=16, bg='#0e0e0e', fg='#ffffff', make_bright=False):
         wallid = re.search("([0-9]+)", wallpaper).groups()[0]
         suffix = '.jpg'
         res = requests.get('http://wallpapers.wallhaven.cc/wallpapers/full/wallhaven-{}.jpg'.format(wallid), stream=True)
@@ -195,7 +219,7 @@ class WallhavenColorParser(KmeansColorParser):
             os.write(dest, block)
         os.close(dest)
 
-        super(WallhavenColorParser, self).__init__(path, config, logger, k, bg, fg)
+        super(WallhavenColorParser, self).__init__(path, config, logger, k, bg, fg, make_bright)
 
     def read(self, *args):
         res = super(WallhavenColorParser, self).read(*args)

--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -188,9 +188,9 @@ class KmeansColorParser(ColorParser):
             'background': self.fg,
             'foreground': self.bg}
         for i, color in enumerate(itertools.cycle(colors)):
-            if i == 0:
+            if i == 15:
                 color = self.normalize(color, minv=0, maxv=32)
-            elif i == 8:
+            elif i == 7:
                 color = self.normalize(color, minv=128, maxv=192)
             elif i > 8:
                 color = self.normalize(color, minv=160, maxv=224)

--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -192,10 +192,10 @@ class KmeansColorParser(ColorParser):
                 color = self.normalize(color, minv=224, maxv=256)
             elif i == 8:
                 color = self.normalize(color, minv=160, maxv=224)
-            elif i > 8:
-                color = self.normalize(color, minv=0, maxv=56)
-            else:
+            elif i < 8:
                 color = self.normalize(color, minv=128, maxv=192)
+            else:
+                color = self.normalize(color, minv=0, maxv=56)
             color_dict['color%d' % i] = color
             if i == 15:
                 break

--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -193,9 +193,9 @@ class KmeansColorParser(ColorParser):
             elif i == 8:
                 color = self.normalize(color, minv=160, maxv=224)
             elif i > 8:
-                color = self.normalize(color, minv=128, maxv=192)
-            else:
                 color = self.normalize(color, minv=0, maxv=56)
+            else:
+                color = self.normalize(color, minv=128, maxv=192)
             color_dict['color%d' % i] = color
             if i == 15:
                 break

--- a/themer/parsers/unsplash.py
+++ b/themer/parsers/unsplash.py
@@ -8,7 +8,7 @@ import os
 class UnsplashColorParser(KmeansColorParser):
     check = 'unsplash.com/.*photo=[_\w\d]+$'
 
-    def __init__(self, wallpaper, config, logger, k=16, bg='#0e0e0e', fg='#ffffff'):
+    def __init__(self, wallpaper, config, logger, k=16, bg='#0e0e0e', fg='#ffffff', make_bright=False):
         wallid = re.search("=([_\w\d]+)$", wallpaper).groups()[0]
         url = "http://unsplash.com/photos/{}/download".format(wallid)
         suffix = '.jpg'
@@ -17,7 +17,7 @@ class UnsplashColorParser(KmeansColorParser):
         for block in res.iter_content(1024):
             os.write(dest, block)
         os.close(dest)
-        super(UnsplashColorParser, self).__init__(path, config, logger, k, bg, fg)
+        super(UnsplashColorParser, self).__init__(path, config, logger, k, bg, fg, make_bright)
 
     def read(self, *args):
         return super(UnsplashColorParser, self).read(*args)


### PR DESCRIPTION
Hi. I made some sketch implementation of my issue #42.
Here is I add additional switcher `-b` for bright.
With switcher I reverse generated colors, so I can have bright backgound.
Here is example for:  https://alpha.wallhaven.cc/wallpaper/375647
![screenshot_20170308_201422](https://cloud.githubusercontent.com/assets/4862907/23707280/fc58f05a-043b-11e7-887f-8cd92f2549dc.png)