### PR TITLE
Actually fix RGB to hex conversion

### DIFF
--- a/themer/parsers/__init__.py
+++ b/themer/parsers/__init__.py
@@ -128,7 +128,7 @@ class KmeansColorParser(ColorParser):
         return points
 
     def rgb_to_hex(self, rgb):
-        return "#{0:X}{1:X}{2:X}".format(*rgb)
+        return "#{0:X}{1:X}{2:X}".format(*(int(i) for i in rgb))
 
     def hex_to_rgb(self, h):
         h = h.lstrip('#')


### PR DESCRIPTION
Looking at the history, it used to do `int` conversion but no longer. Floats are passed here.

Before:

```python
$ themer generate grainy_ocean vaYTNt7.jpg

Traceback (most recent call last):
  File "/home/coxley/.local/bin/themer", line 323, in <module>
    generate(color_file, config, template_dir, theme_name, options.bright)
  File "/home/coxley/.local/bin/themer", line 170, in generate
    colors = parse.read()
  File "/home/coxley/.local/lib/python3.6/site-packages/themer/parsers/__init__.py", line 160, in read
    color_dict = self.bright(colors) if self.make_bright else self.dark(colors)
  File "/home/coxley/.local/lib/python3.6/site-packages/themer/parsers/__init__.py", line 173, in dark
    color = self.normalize(color, minv=0, maxv=32)
  File "/home/coxley/.local/lib/python3.6/site-packages/themer/parsers/__init__.py", line 156, in normalize
    return self.rgb_to_hex(map(lambda i: i * 256, rgb))
  File "/home/coxley/.local/lib/python3.6/site-packages/themer/parsers/__init__.py", line 131, in rgb_to_hex
    return "#{0:X}{1:X}{2:X}".format(*rgb)
ValueError: Unknown format code 'X' for object of type 'float'
```

After:

```
$ themer generate grainy_ocean vaYTNt7.jpg
Activate now? yN y
```